### PR TITLE
Fix thoughts

### DIFF
--- a/Defs/hopper-disable.xml
+++ b/Defs/hopper-disable.xml
@@ -4,6 +4,8 @@
         <!--
         This definition, is to override the base-game hopper, since my NPD doesn't make use of it.
         i.e. Make empty building with same name, that isn't listed anywhere to build.
+        Many things reference it, so I can't just remove it with a patch:
+            "Failed to find Verse.ThingDef named Hopper. There are 1178 defs of this type loaded."
         -->
         <defName>Hopper</defName>
         <label>hopper</label>

--- a/Defs/nutrients-fruit.xml
+++ b/Defs/nutrients-fruit.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+    <ThingDef Name="MealFruitLeather" ParentName="MealNutrientBase">
+        <defName>MealFruitLeather</defName>
+        <label>fruit leather</label>
+        <description>Dehydrated fruit. It's sweet taste makes up for its bland texture, but also makes you thirsty.</description>
+
+        <graphicData>
+            <graphicClass>Graphic_StackCount</graphicClass>
+            <texPath>Things/Item/Resource/Cloth</texPath>
+            <color>(90, 0, 130)</color>
+        </graphicData>
+
+        <stackLimit>13</stackLimit>
+        <statBases>
+            <MaxHitPoints>50</MaxHitPoints>
+            <DeteriorationRate>8</DeteriorationRate>
+            <Nutrition>0.9</Nutrition>
+            <MarketValue>18</MarketValue> <!-- simple meals are 15, survival packs are 25 -->
+            <Mass>0.27</Mass>
+        </statBases>
+        <comps>
+            <li Class="CompProperties_Rottable">
+                <daysToRotStart>25</daysToRotStart> <!-- potatoes/rawfungus 30, agave 25, berries 14 -->
+                <rotDestroys>true</rotDestroys>
+            </li>
+        </comps>
+        <tradeability>Sellable</tradeability>
+        <ingestible>
+            <preferability>MealSimple</preferability>
+            <optimalityOffsetHumanlikes>10</optimalityOffsetHumanlikes>
+        </ingestible>
+    </ThingDef>
+</Defs>

--- a/Defs/nutrients-human.xml
+++ b/Defs/nutrients-human.xml
@@ -1,33 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
-    <HediffDef Name="AteHumanHediffBase" Abstract="True">
-        <!--
-        This hediff should be invisible; It's just so I can give thoughts seperately for cannibals.
-        No problems found so far, but I'm leaving these commented-out just in case,
-        so it's easier to debug / remember what I might need to add back in.
-        (copied from Flake...)
-        -->
-        <!--<label>high on flake</label>-->
-        <!--<labelNoun>a flake high</labelNoun>-->
-        <!--<defaultLabelColor>(1,0,0.5)</defaultLabelColor>-->
-
-        <hediffClass>HediffWithComps</hediffClass>
-        <scenarioCanAdd>false</scenarioCanAdd>
-        <maxSeverity>1.0</maxSeverity>
-        <isBad>true</isBad>
-        <comps>
-            <li Class="HediffCompProperties_SeverityPerDay">
-                <severityPerDay>-1.1</severityPerDay>
-            </li>
-        </comps>
-        <stages>
-            <li>
-                <!--invisible, no problems?-->
-            </li>
-        </stages>
-    </HediffDef>
-
-
     <ThingDef ParentName="MealNutrientPasteBase">
         <defName>MealHumanPaste</defName>
         <label>human paste meal</label>
@@ -38,51 +10,16 @@
             <optimalityOffsetHumanlikes>-35</optimalityOffsetHumanlikes>
             <outcomeDoers>
                 <li Class="IngestionOutcomeDoer_GiveHediff">
-                    <hediffDef>AteHumanPaste</hediffDef>
+                    <hediffDef>AteNutrientsHuman</hediffDef>
+                    <severity>1.0</severity>
+                </li>
+                <li Class="IngestionOutcomeDoer_GiveHediff">
+                    <hediffDef>AteNutrientPaste</hediffDef>
                     <severity>1.0</severity>
                 </li>
             </outcomeDoers>
         </ingestible>
     </ThingDef>
-
-    <HediffDef ParentName="AteHumanHediffBase">
-        <defName>AteHumanPaste</defName>
-    </HediffDef>
-
-    <ThoughtDef>
-        <defName>AteHumanPasteThought</defName>
-
-        <workerClass>ThoughtWorker_Hediff</workerClass>
-        <hediff>AteHumanPaste</hediff>
-        <nullifyingTraits>
-			<li>Cannibal</li>
-		</nullifyingTraits>
-        <stages>
-            <li>
-                <label>ate human paste</label>
-                <description>I'm eating human flesh that's been processed into a greasy slime. They didn't even get the dignity of being cooked by hand...</description>
-                <baseMoodEffect>-25</baseMoodEffect>
-            </li>
-        </stages>
-    </ThoughtDef>
-
-    <ThoughtDef>
-        <defName>AteHumanPasteAsCannibalThought</defName>
-
-        <workerClass>ThoughtWorker_Hediff</workerClass>
-        <hediff>AteHumanPaste</hediff>
-        <requiredTraits>
-            <li>Cannibal</li>
-        </requiredTraits>
-        <stages>
-            <li>
-                <label>ate human paste</label>
-                <description>What a waste of tasty human flesh!</description>
-                <baseMoodEffect>10</baseMoodEffect>
-            </li>
-        </stages>
-    </ThoughtDef>
-
 
     <ThingDef ParentName="MealNutrientBrickBase">
         <defName>MealHumanBrick</defName>
@@ -98,47 +35,55 @@
             <optimalityOffsetHumanlikes>-40</optimalityOffsetHumanlikes>
             <outcomeDoers>
                 <li Class="IngestionOutcomeDoer_GiveHediff">
-                    <hediffDef>AteHumanBrick</hediffDef>
+                    <hediffDef>AteNutrientsHuman</hediffDef>
+                    <severity>1.0</severity>
+                </li>
+                <li Class="IngestionOutcomeDoer_GiveHediff">
+                    <hediffDef>AteNutrientBrick</hediffDef>
                     <severity>1.0</severity>
                 </li>
             </outcomeDoers>
         </ingestible>
     </ThingDef>
 
-    <HediffDef ParentName="AteHumanHediffBase">
-        <defName>AteHumanBrick</defName>
+
+    <HediffDef ParentName="AteNutrientHediffBase">
+        <defName>AteNutrientsHuman</defName>
+        <label>human nutrients</label>
+        <labelNoun>some human nutrients</labelNoun>
+        <defaultLabelColor>(200, 120, 100)</defaultLabelColor>
     </HediffDef>
 
     <ThoughtDef>
-        <defName>AteHumanBrick</defName>
+        <defName>AteHumanNutrientsThought</defName>
 
         <workerClass>ThoughtWorker_Hediff</workerClass>
-        <hediff>AteHumanBrick</hediff>
+        <hediff>AteNutrientsHuman</hediff>
         <nullifyingTraits>
 			<li>Cannibal</li>
 		</nullifyingTraits>
         <stages>
             <li>
-                <label>ate human brick</label>
-                <description>Human flesh, processed into a small brick. How did we get to this point? People are getting chopped up, churned, dried, pickled, eaten, stewed, ground to paste - I can't stand it!</description>
-                <baseMoodEffect>-37</baseMoodEffect>
+                <label>ate human nutrients</label>
+                <description>At least this human flesh has been processed enough that it's almost unrecognizable.</description>
+                <baseMoodEffect>-99</baseMoodEffect>
             </li>
         </stages>
     </ThoughtDef>
 
     <ThoughtDef>
-        <defName>AteHumanBrickAsCannibal</defName>
+        <defName>AteHumanNutrientsAsCannibalThought</defName>
 
         <workerClass>ThoughtWorker_Hediff</workerClass>
-        <hediff>AteHumanBrick</hediff>
+        <hediff>AteNutrientsHuman</hediff>
         <requiredTraits>
             <li>Cannibal</li>
         </requiredTraits>
         <stages>
             <li>
-                <label>ate human brick</label>
-                <description>Human flesh, processed into a small brick. I can barely even taste the distinctive flavor!</description>
-                <baseMoodEffect>5</baseMoodEffect>
+                <label>ate human nutrients</label>
+                <description>I can barely taste the distinctive flavor!</description>
+                <baseMoodEffect>10</baseMoodEffect>
             </li>
         </stages>
     </ThoughtDef>

--- a/Defs/nutrients-human.xml
+++ b/Defs/nutrients-human.xml
@@ -1,11 +1,33 @@
 <?xml version="1.0" encoding="utf-8" ?>
-
-<!--
-TODO: make this work with the cannibalism trait.
-Maybe make these like drugs, and use invisible hediffs, which give two or more thoughts?
--->
-
 <Defs>
+    <HediffDef Name="AteHumanHediffBase" Abstract="True">
+        <!--
+        This hediff should be invisible; It's just so I can give thoughts seperately for cannibals.
+        No problems found so far, but I'm leaving these commented-out just in case,
+        so it's easier to debug / remember what I might need to add back in.
+        (copied from Flake...)
+        -->
+        <!--<label>high on flake</label>-->
+        <!--<labelNoun>a flake high</labelNoun>-->
+        <!--<defaultLabelColor>(1,0,0.5)</defaultLabelColor>-->
+
+        <hediffClass>HediffWithComps</hediffClass>
+        <scenarioCanAdd>false</scenarioCanAdd>
+        <maxSeverity>1.0</maxSeverity>
+        <isBad>true</isBad>
+        <comps>
+            <li Class="HediffCompProperties_SeverityPerDay">
+                <severityPerDay>-1.1</severityPerDay>
+            </li>
+        </comps>
+        <stages>
+            <li>
+                <!--invisible, no problems?-->
+            </li>
+        </stages>
+    </HediffDef>
+
+
     <ThingDef ParentName="MealNutrientPasteBase">
         <defName>MealHumanPaste</defName>
         <label>human paste meal</label>
@@ -14,18 +36,49 @@ Maybe make these like drugs, and use invisible hediffs, which give two or more t
         <ingestible>
             <preferability>MealAwful</preferability>
             <optimalityOffsetHumanlikes>-35</optimalityOffsetHumanlikes>
-            <tasteThought>AteHumanPaste</tasteThought>
+            <outcomeDoers>
+                <li Class="IngestionOutcomeDoer_GiveHediff">
+                    <hediffDef>AteHumanPaste</hediffDef>
+                    <severity>1.0</severity>
+                </li>
+            </outcomeDoers>
         </ingestible>
     </ThingDef>
 
-    <ThoughtDef ParentName="NutrientThoughtBase">
+    <HediffDef ParentName="AteHumanHediffBase">
         <defName>AteHumanPaste</defName>
+    </HediffDef>
 
+    <ThoughtDef>
+        <defName>AteHumanPasteThought</defName>
+
+        <workerClass>ThoughtWorker_Hediff</workerClass>
+        <hediff>AteHumanPaste</hediff>
+        <nullifyingTraits>
+			<li>Cannibal</li>
+		</nullifyingTraits>
         <stages>
             <li>
                 <label>ate human paste</label>
                 <description>I'm eating human flesh that's been processed into a greasy slime. They didn't even get the dignity of being cooked by hand...</description>
                 <baseMoodEffect>-25</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
+
+    <ThoughtDef>
+        <defName>AteHumanPasteAsCannibalThought</defName>
+
+        <workerClass>ThoughtWorker_Hediff</workerClass>
+        <hediff>AteHumanPaste</hediff>
+        <requiredTraits>
+            <li>Cannibal</li>
+        </requiredTraits>
+        <stages>
+            <li>
+                <label>ate human paste</label>
+                <description>What a waste of tasty human flesh!</description>
+                <baseMoodEffect>10</baseMoodEffect>
             </li>
         </stages>
     </ThoughtDef>
@@ -43,18 +96,49 @@ Maybe make these like drugs, and use invisible hediffs, which give two or more t
         <ingestible>
             <preferability>MealAwful</preferability>
             <optimalityOffsetHumanlikes>-40</optimalityOffsetHumanlikes>
-            <tasteThought>AteHumanBrick</tasteThought>
+            <outcomeDoers>
+                <li Class="IngestionOutcomeDoer_GiveHediff">
+                    <hediffDef>AteHumanBrick</hediffDef>
+                    <severity>1.0</severity>
+                </li>
+            </outcomeDoers>
         </ingestible>
     </ThingDef>
 
-    <ThoughtDef ParentName="NutrientThoughtBase">
+    <HediffDef ParentName="AteHumanHediffBase">
+        <defName>AteHumanBrick</defName>
+    </HediffDef>
+
+    <ThoughtDef>
         <defName>AteHumanBrick</defName>
 
+        <workerClass>ThoughtWorker_Hediff</workerClass>
+        <hediff>AteHumanBrick</hediff>
+        <nullifyingTraits>
+			<li>Cannibal</li>
+		</nullifyingTraits>
         <stages>
             <li>
-                <label>ate nutrient brick</label>
+                <label>ate human brick</label>
                 <description>Human flesh, processed into a small brick. How did we get to this point? People are getting chopped up, churned, dried, pickled, eaten, stewed, ground to paste - I can't stand it!</description>
                 <baseMoodEffect>-37</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
+
+    <ThoughtDef>
+        <defName>AteHumanBrickAsCannibal</defName>
+
+        <workerClass>ThoughtWorker_Hediff</workerClass>
+        <hediff>AteHumanBrick</hediff>
+        <requiredTraits>
+            <li>Cannibal</li>
+        </requiredTraits>
+        <stages>
+            <li>
+                <label>ate human brick</label>
+                <description>Human flesh, processed into a small brick. I can barely even taste the distinctive flavor!</description>
+                <baseMoodEffect>5</baseMoodEffect>
             </li>
         </stages>
     </ThoughtDef>

--- a/Defs/nutrients-human.xml
+++ b/Defs/nutrients-human.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<!--
+TODO: make this work with the cannibalism trait.
+Maybe make these like drugs, and use invisible hediffs, which give two or more thoughts?
+-->
+
+<Defs>
+    <ThingDef ParentName="MealNutrientPasteBase">
+        <defName>MealHumanPaste</defName>
+        <label>human paste meal</label>
+        <description>A greasy slime made from processed human meat.</description>
+
+        <ingestible>
+            <preferability>MealAwful</preferability>
+            <optimalityOffsetHumanlikes>-35</optimalityOffsetHumanlikes>
+            <tasteThought>AteHumanPaste</tasteThought>
+        </ingestible>
+    </ThingDef>
+
+    <ThoughtDef ParentName="NutrientThoughtBase">
+        <defName>AteHumanPaste</defName>
+
+        <stages>
+            <li>
+                <label>ate human paste</label>
+                <description>I'm eating human flesh that's been processed into a greasy slime. They didn't even get the dignity of being cooked by hand...</description>
+                <baseMoodEffect>-25</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
+
+
+    <ThingDef ParentName="MealNutrientBrickBase">
+        <defName>MealHumanBrick</defName>
+        <label>human brick meal</label>
+        <description>Dehydrated human paste, wrapped in polymer made from inedible food-parts. The bright color makes them easily distinguishable from other nutrient bricks.</description>
+
+        <graphicData>
+            <color>(200, 120, 100)</color>
+        </graphicData>
+
+        <ingestible>
+            <preferability>MealAwful</preferability>
+            <optimalityOffsetHumanlikes>-40</optimalityOffsetHumanlikes>
+            <tasteThought>AteHumanBrick</tasteThought>
+        </ingestible>
+    </ThingDef>
+
+    <ThoughtDef ParentName="NutrientThoughtBase">
+        <defName>AteHumanBrick</defName>
+
+        <stages>
+            <li>
+                <label>ate nutrient brick</label>
+                <description>Human flesh, processed into a small brick. How did we get to this point? People are getting chopped up, churned, dried, pickled, eaten, stewed, ground to paste - I can't stand it!</description>
+                <baseMoodEffect>-37</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
+</Defs>

--- a/Defs/nutrients-insect.xml
+++ b/Defs/nutrients-insect.xml
@@ -8,22 +8,18 @@
         <ingestible>
             <preferability>MealAwful</preferability>
             <optimalityOffsetHumanlikes>-20</optimalityOffsetHumanlikes>
-            <tasteThought>AteInsectPaste</tasteThought>
+            <outcomeDoers>
+                <li Class="IngestionOutcomeDoer_GiveHediff">
+                    <hediffDef>AteNutrientsInsect</hediffDef>
+                    <severity>1.0</severity>
+                </li>
+                <li Class="IngestionOutcomeDoer_GiveHediff">
+                    <hediffDef>AteNutrientPaste</hediffDef>
+                    <severity>1.0</severity>
+                </li>
+            </outcomeDoers>
         </ingestible>
     </ThingDef>
-
-    <ThoughtDef ParentName="NutrientThoughtBase">
-        <defName>AteInsectPaste</defName>
-
-        <stages>
-            <li>
-                <label>ate insect paste</label>
-                <description>I ate a tube full of processed insect-parts. The gear-oil helps mask the taste a bit.</description>
-                <baseMoodEffect>-10</baseMoodEffect>
-            </li>
-        </stages>
-    </ThoughtDef>
-
 
     <ThingDef ParentName="MealNutrientBrickBase">
         <defName>MealInsectBrick</defName>
@@ -37,18 +33,57 @@
         <ingestible>
             <preferability>MealAwful</preferability>
             <optimalityOffsetHumanlikes>-25</optimalityOffsetHumanlikes>
-            <tasteThought>AteInsectBrick</tasteThought>
+            <outcomeDoers>
+                <li Class="IngestionOutcomeDoer_GiveHediff">
+                    <hediffDef>AteNutrientsInsect</hediffDef>
+                    <severity>1.0</severity>
+                </li>
+                <li Class="IngestionOutcomeDoer_GiveHediff">
+                    <hediffDef>AteNutrientBrick</hediffDef>
+                    <severity>1.0</severity>
+                </li>
+            </outcomeDoers>
         </ingestible>
     </ThingDef>
 
-    <ThoughtDef ParentName="NutrientThoughtBase">
-        <defName>AteInsectBrick</defName>
 
+    <HediffDef ParentName="AteNutrientHediffBase">
+        <defName>AteNutrientsInsect</defName>
+        <label>insect nutrients</label>
+        <labelNoun>some insect nutrients</labelNoun>
+        <defaultLabelColor>(100, 100, 100)</defaultLabelColor>
+    </HediffDef>
+
+    <ThoughtDef>
+        <defName>AteInsectNutrientsThought</defName>
+
+        <workerClass>ThoughtWorker_Hediff</workerClass>
+        <hediff>AteNutrientsInsect</hediff>
+        <nullifyingTraits>
+			<li>Ascetic</li>
+		</nullifyingTraits>
         <stages>
             <li>
-                <label>ate insect brick</label>
-                <description>The dehydration process actually lessens the flavor of insect guts. It's still terrible, but it could be worse.</description>
-                <baseMoodEffect>-15</baseMoodEffect>
+                <label>ate insect nutrients</label>
+                <description>At least this insect flesh has been highly processed...</description>
+                <baseMoodEffect>-4</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
+
+    <ThoughtDef>
+        <defName>AteInsectNutrientsAsAsceticThought</defName>
+
+        <workerClass>ThoughtWorker_Hediff</workerClass>
+        <hediff>AteNutrientsInsect</hediff>
+        <requiredTraits>
+            <li>Ascetic</li>
+        </requiredTraits>
+        <stages>
+            <li>
+                <label>ate insect nutrients</label>
+                <description>I don't mind insect flesh...that much.</description>
+                <baseMoodEffect>-2</baseMoodEffect>
             </li>
         </stages>
     </ThoughtDef>

--- a/Defs/nutrients-insect.xml
+++ b/Defs/nutrients-insect.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+    <ThingDef ParentName="MealNutrientPasteBase">
+        <defName>MealInsectPaste</defName>
+        <label>insect paste meal</label>
+        <description>A coarse slime made from processed insect meat.</description>
+
+        <ingestible>
+            <preferability>MealAwful</preferability>
+            <optimalityOffsetHumanlikes>-20</optimalityOffsetHumanlikes>
+            <tasteThought>AteInsectPaste</tasteThought>
+        </ingestible>
+    </ThingDef>
+
+    <ThoughtDef ParentName="NutrientThoughtBase">
+        <defName>AteInsectPaste</defName>
+
+        <stages>
+            <li>
+                <label>ate insect paste</label>
+                <description>I ate a tube full of processed insect-parts. The gear-oil helps mask the taste a bit.</description>
+                <baseMoodEffect>-10</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
+
+
+    <ThingDef ParentName="MealNutrientBrickBase">
+        <defName>MealInsectBrick</defName>
+        <label>insect brick meal</label>
+        <description>Dehydrated insect paste, wrapped in polymer made from inedible food-parts. Colloquially referred to as Bug-Bricks, in a hopeless attempt to distract from the taste.</description>
+
+        <graphicData>
+            <color>(100, 100, 100)</color>
+        </graphicData>
+
+        <ingestible>
+            <preferability>MealAwful</preferability>
+            <optimalityOffsetHumanlikes>-25</optimalityOffsetHumanlikes>
+            <tasteThought>AteInsectBrick</tasteThought>
+        </ingestible>
+    </ThingDef>
+
+    <ThoughtDef ParentName="NutrientThoughtBase">
+        <defName>AteInsectBrick</defName>
+
+        <stages>
+            <li>
+                <label>ate insect brick</label>
+                <description>The dehydration process actually lessens the flavor of insect guts. It's still terrible, but it could be worse.</description>
+                <baseMoodEffect>-15</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
+</Defs>

--- a/Defs/nutrients.xml
+++ b/Defs/nutrients.xml
@@ -59,22 +59,34 @@
         </ingestible>
     </ThingDef>
 
-    <ThoughtDef Name="NutrientThoughtBase" Abstract="True">
-        <showBubble>true</showBubble>
-        <icon>Things/Mote/ThoughtSymbol/Food</icon>
-        <durationDays>1</durationDays>
-        <!--
-        mood:
-            -20 raw cannibalism
-            -15 cooked cannibalism
-            -12 kibble
-             -7 raw food
-             -6 insect meat
-             -4 base-game nutrient paste
-            +15 cooked cannibalism as cannibal
-            +20 raw cannibalism as cannibal
-        -->
-    </ThoughtDef>
+    <HediffDef Name="AteNutrientHediffBase" Abstract="True">
+        <hediffClass>HediffWithComps</hediffClass>
+        <scenarioCanAdd>false</scenarioCanAdd>
+        <maxSeverity>1.0</maxSeverity>
+        <isBad>true</isBad>
+        <comps>
+            <li Class="HediffCompProperties_SeverityPerDay">
+                <severityPerDay>-1.0</severityPerDay>
+            </li>
+        </comps>
+        <stages>
+            <li>
+                <!-- no properties, no problems? -->
+            </li>
+        </stages>
+    </HediffDef>
+
+    <!--
+    thought moods:
+        -20 raw cannibalism
+        -15 cooked cannibalism
+        -12 kibble
+         -7 raw food
+         -6 insect meat
+         -4 base-game nutrient paste
+        +15 cooked cannibalism as cannibal
+        +20 raw cannibalism as cannibal
+    -->
 
 
 
@@ -101,15 +113,21 @@
         <tradeability>Buyable</tradeability>
     </ThingDef>
 
+    <HediffDef ParentName="AteNutrientHediffBase">
+        <defName>AteNutrientPaste</defName>
+        <label>nutrient paste</label>
+        <labelNoun>a nutrient paste</labelNoun>
+        <defaultLabelColor>(120, 140, 80)</defaultLabelColor>
+    </HediffDef>
 
-    <!--
-    MealNutrientPaste is defined in a patch file to override the base game, because trying to delete it entirely is bad.
-    (Too many things in base game reference it.)
-    -->
-
-    <ThoughtDef ParentName="NutrientThoughtBase">
+    <ThoughtDef>
         <defName>AteNutrientPaste</defName>
 
+        <workerClass>ThoughtWorker_Hediff</workerClass>
+        <hediff>AteNutrientPaste</hediff>
+        <nullifyingTraits>
+			<li>Ascetic</li>
+		</nullifyingTraits>
         <stages>
             <li>
                 <label>ate nutrient paste</label>
@@ -118,6 +136,29 @@
             </li>
         </stages>
     </ThoughtDef>
+
+    <ThoughtDef>
+        <defName>AteNutrientPasteAsAscetic</defName>
+
+        <workerClass>ThoughtWorker_Hediff</workerClass>
+        <hediff>AteNutrientPaste</hediff>
+        <requiredTraits>
+            <li>Ascetic</li>
+        </requiredTraits>
+        <stages>
+            <li>
+                <label>ate nutrient paste</label>
+                <description>This nutrient paste is very bland. I like it.</description>
+                <baseMoodEffect>1</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
+
+
+    <!--
+    MealNutrientPaste is defined in a patch file to override the base game, because trying to delete it entirely is bad.
+    (Too many things in base game reference it.)
+    -->
 
 
 
@@ -147,6 +188,47 @@
         </ingestible>
     </ThingDef>
 
+    <HediffDef ParentName="AteNutrientHediffBase">
+        <defName>AteNutrientBrick</defName>
+        <label>nutrient brick</label>
+        <labelNoun>a nutrient brick</labelNoun>
+        <defaultLabelColor>(120, 140, 80)</defaultLabelColor>
+    </HediffDef>
+
+    <ThoughtDef>
+        <defName>AteNutrientBrick</defName>
+
+        <workerClass>ThoughtWorker_Hediff</workerClass>
+        <hediff>AteNutrientBrick</hediff>
+        <nullifyingTraits>
+			<li>Ascetic</li>
+		</nullifyingTraits>
+        <stages>
+            <li>
+                <label>ate nutrient brick</label>
+                <description>I ate a brick of dehydrated nutrient-paste. I'd like to say that it tastes just as bad as the paste, but now it also tastes burnt, from the dehydration process.</description>
+                <baseMoodEffect>-6</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
+
+    <ThoughtDef>
+        <defName>AteNutrientBrickAsAscetic</defName>
+
+        <workerClass>ThoughtWorker_Hediff</workerClass>
+        <hediff>AteNutrientBrick</hediff>
+        <requiredTraits>
+            <li>Ascetic</li>
+        </requiredTraits>
+        <stages>
+            <li>
+                <label>ate nutrient brick</label>
+                <description>This nutrient brick is very bland, dry, and a bit burned - I like it!</description>
+                <baseMoodEffect>2</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
+
 
     <ThingDef ParentName="MealNutrientBrickBase">
         <defName>MealNutrientBrick</defName>
@@ -160,19 +242,12 @@
         <ingestible>
             <preferability>MealAwful</preferability>
             <optimalityOffsetHumanlikes>-15</optimalityOffsetHumanlikes>
-            <tasteThought>AteNutrientBrickMeal</tasteThought>
+            <outcomeDoers>
+                <li Class="IngestionOutcomeDoer_GiveHediff">
+                    <hediffDef>AteNutrientBrick</hediffDef>
+                    <severity>1.0</severity>
+                </li>
+            </outcomeDoers>
         </ingestible>
     </ThingDef>
-
-    <ThoughtDef ParentName="NutrientThoughtBase">
-        <defName>AteNutrientBrickMeal</defName>
-
-        <stages>
-            <li>
-                <label>ate nutrient brick</label>
-                <description>I ate a brick of dehydrated nutrient-paste. I'd like to say that it tastes just as bad as the paste, but now it also tastes burnt, from the dehydration process.</description>
-                <baseMoodEffect>-6</baseMoodEffect>
-            </li>
-        </stages>
-    </ThoughtDef>
 </Defs>

--- a/Defs/nutrients.xml
+++ b/Defs/nutrients.xml
@@ -35,7 +35,6 @@
             <maxNumToIngestAtOnce>1</maxNumToIngestAtOnce>
             <ingestEffect>EatVegetarian</ingestEffect>
             <ingestSound>Meal_Eat</ingestSound>
-
             <!--
             preferability:
                 NeverForNutrition
@@ -64,7 +63,6 @@
         <showBubble>true</showBubble>
         <icon>Things/Mote/ThoughtSymbol/Food</icon>
         <durationDays>1</durationDays>
-
         <!--
         mood:
             -20 raw cannibalism
@@ -73,6 +71,8 @@
              -7 raw food
              -6 insect meat
              -4 base-game nutrient paste
+            +15 cooked cannibalism as cannibal
+            +20 raw cannibalism as cannibal
         -->
     </ThoughtDef>
 

--- a/Defs/nutrients.xml
+++ b/Defs/nutrients.xml
@@ -29,31 +29,54 @@
             (The base game bypasses normal item-generation, and thus ignores this tag.)
             -->
             <li Class="CompProperties_Forbiddable"/>
-            <li Class="CompProperties_Ingredients"/>
         </comps>
         <ingestible>
             <foodType>Meal</foodType>
             <maxNumToIngestAtOnce>1</maxNumToIngestAtOnce>
             <ingestEffect>EatVegetarian</ingestEffect>
             <ingestSound>Meal_Eat</ingestSound>
-            <preferability>MealAwful</preferability>
+
+            <!--
+            preferability:
+                NeverForNutrition
+                DesperateOnly
+                DesperateOnlyForHumanlikes
+                RawBad
+                RawTasty
+                MealAwful
+                MealSimple
+                MealFine
+                MealLavish
+
+            optimalityOffsetHumanlikes:
+                I *think* the optimality offset is checked second, after preferability.
+                But maybe it overrides what the preferability would do?
+                Negative is worse / eaten later, positive is better / eaten earlier?
+                -30 kibble (RawBad)
+                 -5 packaged survival meal (MealSimple)
+                  5 pemmican (MealSimple)
+                 16 MealBase (???)
+            -->
         </ingestible>
     </ThingDef>
 
-
-    <ThoughtDef>
-        <defName>AteNutrientPasteMeal</defName>
+    <ThoughtDef Name="NutrientThoughtBase" Abstract="True">
         <showBubble>true</showBubble>
         <icon>Things/Mote/ThoughtSymbol/Food</icon>
         <durationDays>1</durationDays>
-        <stages>
-            <li>
-                <label>ate nutrient paste</label>
-                <description>My meal was a tube full of gritty, bitter slime. It's keeping me alive, but it's hard to keep down.</description>
-                <baseMoodEffect>-4</baseMoodEffect>
-            </li>
-        </stages>
+
+        <!--
+        mood:
+            -20 raw cannibalism
+            -15 cooked cannibalism
+            -12 kibble
+             -7 raw food
+             -6 insect meat
+             -4 base-game nutrient paste
+        -->
     </ThoughtDef>
+
+
 
     <ThingDef Name="MealNutrientPasteBase" ParentName="MealNutrientBase" Abstract="True">
         <graphicData>
@@ -76,76 +99,27 @@
             </li>
         </comps>
         <tradeability>Buyable</tradeability>
-        <ingestible>
-            <optimalityOffsetHumanlikes>-6</optimalityOffsetHumanlikes> <!-- I *think* the optimality offset is checked second, after preferability of MealAwful, which would end up with pawns eating paste when there's simple meals nearby. (Seemed to happen with my bricks, so I'm patching this on paste.) -->
-            <tasteThought>AteNutrientPasteMeal</tasteThought>
-        </ingestible>
     </ThingDef>
+
 
     <!--
     MealNutrientPaste is defined in a patch file to override the base game, because trying to delete it entirely is bad.
     (Too many things in base game reference it.)
     -->
 
-    <ThingDef ParentName="MealNutrientPasteBase">
-        <defName>MealInsectPaste</defName>
-        <label>insect paste meal</label>
-        <description>A coarse slime made from processed insect meat.</description>
-    </ThingDef>
+    <ThoughtDef ParentName="NutrientThoughtBase">
+        <defName>AteNutrientPaste</defName>
 
-    <ThingDef ParentName="MealNutrientPasteBase">
-        <defName>MealHumanPaste</defName>
-        <label>human paste meal</label>
-        <description>A greasy slime made from processed human meat.</description>
-    </ThingDef>
-
-
-    <ThingDef Name="MealFruitLeather" ParentName="MealNutrientBase">
-        <defName>MealFruitLeather</defName>
-        <label>fruit leather</label>
-        <description>Dehydrated fruit. It's sweet taste makes up for its bland texture, but also makes you thirsty.</description>
-
-        <graphicData>
-            <graphicClass>Graphic_StackCount</graphicClass>
-            <texPath>Things/Item/Resource/Cloth</texPath>
-            <color>(90, 0, 130)</color>
-        </graphicData>
-
-        <stackLimit>13</stackLimit>
-        <statBases>
-            <MaxHitPoints>50</MaxHitPoints>
-            <DeteriorationRate>8</DeteriorationRate>
-            <Nutrition>0.9</Nutrition>
-            <MarketValue>18</MarketValue> <!-- simple meals are 15, survival packs are 25 -->
-            <Mass>0.27</Mass>
-        </statBases>
-        <comps>
-            <li Class="CompProperties_Rottable">
-                <daysToRotStart>25</daysToRotStart> <!-- potatoes/rawfungus 30, agave 25, berries 14 -->
-                <rotDestroys>true</rotDestroys>
-            </li>
-        </comps>
-        <tradeability>Sellable</tradeability>
-        <ingestible>
-            <preferability>MealSimple</preferability>
-            <optimalityOffsetHumanlikes>10</optimalityOffsetHumanlikes> <!-- I *think* the optimality offset is checked second, after preferability of MealAwful, which would end up with pawns eating paste when there's simple meals nearby. (Seemed to happen with my bricks, so I'm patching this on paste.) -->
-        </ingestible>
-    </ThingDef>
-
-
-    <ThoughtDef>
-        <defName>AteNutrientBrickMeal</defName>
-        <showBubble>true</showBubble>
-        <icon>Things/Mote/ThoughtSymbol/Food</icon>
-        <durationDays>1</durationDays>
         <stages>
             <li>
-                <label>ate nutrient brick</label>
-                <description>I ate a brick of dehydrated nutrient-paste. I'd like to say that it tastes just as bad as the paste, but now it also tastes burnt, from the dehydration process.</description>
-                <baseMoodEffect>-6</baseMoodEffect> <!-- kibble is -12; raw food is -7; nutrient paste is -4, pemmican is 0 -->
+                <label>ate nutrient paste</label>
+                <description>I ate a tube full of gritty, bitter slime. It's keeping me alive, but it's hard to keep down.</description>
+                <baseMoodEffect>-4</baseMoodEffect>
             </li>
         </stages>
     </ThoughtDef>
+
+
 
     <ThingDef Name="MealNutrientBrickBase" ParentName="MealNutrientBase" Abstract="True">
         <graphicData>
@@ -169,11 +143,10 @@
         </comps>
         <tradeability>Sellable</tradeability>
         <ingestible>
-            <optimalityOffsetHumanlikes>-7</optimalityOffsetHumanlikes> <!-- I *think* the optimality offset is checked second, after preferability of MealAwful, which would end up with pawns eating paste when there's simple meals nearby. (Seemed to happen with my bricks, so I'm patching this on paste.) -->
-            <tasteThought>AteNutrientBrickMeal</tasteThought>
             <baseIngestTicks>1500</baseIngestTicks>  <!-- Not sure how slow meals are - they don't have any values defined in XML. Maybe 600? Seems like 60 ticks per second. -->
         </ingestible>
     </ThingDef>
+
 
     <ThingDef ParentName="MealNutrientBrickBase">
         <defName>MealNutrientBrick</defName>
@@ -183,25 +156,23 @@
         <graphicData>
             <color>(120, 140, 80)</color>
         </graphicData>
+
+        <ingestible>
+            <preferability>MealAwful</preferability>
+            <optimalityOffsetHumanlikes>-15</optimalityOffsetHumanlikes>
+            <tasteThought>AteNutrientBrickMeal</tasteThought>
+        </ingestible>
     </ThingDef>
 
-    <ThingDef ParentName="MealNutrientBrickBase">
-        <defName>MealInsectBrick</defName>
-        <label>insect brick meal</label>
-        <description>Dehydrated insect paste, wrapped in polymer made from inedible food-parts. Colloquially referred to as Bug-Bricks, in a hopeless attempt to distract from the taste.</description>
+    <ThoughtDef ParentName="NutrientThoughtBase">
+        <defName>AteNutrientBrickMeal</defName>
 
-        <graphicData>
-            <color>(100, 100, 100)</color>
-        </graphicData>
-    </ThingDef>
-
-    <ThingDef ParentName="MealNutrientBrickBase">
-        <defName>MealHumanBrick</defName>
-        <label>human brick meal</label>
-        <description>Dehydrated human paste, wrapped in polymer made from inedible food-parts. The bright color makes them easily distinguishable from other nutrient bricks.</description>
-
-        <graphicData>
-            <color>(200, 120, 100)</color>
-        </graphicData>
-    </ThingDef>
+        <stages>
+            <li>
+                <label>ate nutrient brick</label>
+                <description>I ate a brick of dehydrated nutrient-paste. I'd like to say that it tastes just as bad as the paste, but now it also tastes burnt, from the dehydration process.</description>
+                <baseMoodEffect>-6</baseMoodEffect>
+            </li>
+        </stages>
+    </ThoughtDef>
 </Defs>

--- a/Patches/nutrient-paste.xml
+++ b/Patches/nutrient-paste.xml
@@ -11,7 +11,12 @@
                 <ingestible>
                     <preferability>MealAwful</preferability>
                     <optimalityOffsetHumanlikes>-10</optimalityOffsetHumanlikes>
-                    <tasteThought>AteNutrientPaste</tasteThought>
+                    <outcomeDoers>
+                        <li Class="IngestionOutcomeDoer_GiveHediff">
+                            <hediffDef>AteNutrientPaste</hediffDef>
+                            <severity>1.0</severity>
+                        </li>
+                    </outcomeDoers>
                 </ingestible>
             </ThingDef>
         </value>

--- a/Patches/nutrient-paste.xml
+++ b/Patches/nutrient-paste.xml
@@ -7,6 +7,12 @@
                 <defName>MealNutrientPaste</defName>
                 <label>nutrient paste meal</label>
                 <description>A synthetic pasteurized mixture of processed macro- and micro-nutrients. Everything the body needs, in a tasteless slime.</description>
+
+                <ingestible>
+                    <preferability>MealAwful</preferability>
+                    <optimalityOffsetHumanlikes>-10</optimalityOffsetHumanlikes>
+                    <tasteThought>AteNutrientPaste</tasteThought>
+                </ingestible>
             </ThingDef>
         </value>
     </Operation>

--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ The official Nutrient Paste Dispenser in Rimworld is a bit old, and has some pro
 - instantaneous paste-production felt weird to me
 
 This mod addresses that, by making the NPD work like a BiofuelRefinery / Stove / work-bench.
-The meals now take time to produce, although are still faster than simple meals, to keep in theme with the original machine.
+The meals now take time to produce, but are still faster than simple meals, to keep in theme with the original machine.
 The nutrients can be made singly (low on resources) or in large batches (slight speed boost).
 Batches also mean pawns aren't constantly hauling to it, even if you don't want to micromanage small stockpiles.
 (I feel like that's in line with the original machine - low-effort, but terrible food.)
-I also added dehydrated nutrient bricks, as a bad replacement for packaged survival meals or pemmican.
-(Slower and tastier than kibble, however, again like survival meals or pemmican.)
+
+Also changed / added:
+- dehydrated nutrient bricks, as a bad replacement for packaged survival meals or pemmican.
+    - (Slower and tastier than kibble, however, again like survival meals or pemmican.)
+- nutrient paste research and packaged survival meal research is more expensive
+- additional research
+    - fruit leather
+    - nutrient bricks
+    - insect nutrients
+    - human nutrients
+- ascetics get a small mood bonus from nutrient paste (and bricks)


### PR DESCRIPTION
Nutrient paste meals (and bricks) would not have thoughts if spawned by cargo-pods by the game, since they lose their ingredients.
This removes the ingredients, and handles thoughts by making the foods give hediffs like drugs.
(These hediffs only add moods, nothing else.)
Ascetics also get a small buff for mood, and the readme is fixed.